### PR TITLE
Konfiguration um SEO42 erweitert

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -36,7 +36,7 @@ $rewriter = array(
         'extension_function'    => 'extension_rewriter_rexseo42',
         'pages'                 => false,
         'subpages'              => true,
-    )
+    ),
     'seo42' => array(
         'extension_point'       => 'REXSEO_ARTICLE_ID_NOT_FOUND',
         'extension_function'    => 'extension_rewriter_rexseo42',


### PR DESCRIPTION
Da die EPs sich nicht geändert haben, muss nur der neue Name angepasst werden.
